### PR TITLE
docs: Document lang method in API Overview section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "html-meta-scraper"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "scraper",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "html-meta-scraper"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "Scrape and extract metadata like title, description, images, and favicon from HTML documents."
-authors = ["Chomolungma Shirayuki"]
+authors = ["Ikuma Yamashita"]
 repository = "https://github.com/46ki75/html-meta-scraper"
 license = "MIT"
 documentation = "https://docs.rs/html-meta-scraper"

--- a/README.md
+++ b/README.md
@@ -48,4 +48,5 @@ assert_eq!(scraper.favicon(), Some("/favicon.ico".to_string()));
 | `description()`     | Retrieves page description (`og:description` → `twitter:description` → `description`) |
 | `image()`           | Retrieves page image URL (`og:image` → `twitter:image`)                               |
 | `favicon()`         | Retrieves favicon URL (`<link rel="icon">`)                                           |
+| `lang()`            | Retrieves language (`<html lang="en">`)                                               |
 | `extract_*` methods | Low-level methods to extract specific metadata                                        |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,29 @@ impl MetaScraper {
         self.extract_og_image()
             .or_else(|| self.extract_twitter_image())
     }
+
+    /// Expected Output: `"en"`
+    /// ```html
+    /// <html lang="en">
+    /// ...
+    /// </html>
+    /// ```
+    pub fn lang(&self) -> Option<String> {
+        let html_selector = scraper::Selector::parse("html").unwrap();
+
+        let lang = self
+            .document
+            .select(&html_selector)
+            .next()
+            .and_then(|element| {
+                element
+                    .value()
+                    .attr("lang")
+                    .map(|content| content.to_string())
+            });
+
+        lang
+    }
 }
 
 #[cfg(test)]
@@ -363,5 +386,20 @@ mod test {
             twitter_image,
             Some("https://example.com/image.jpg".to_string())
         );
+    }
+
+    #[test]
+    fn lang() {
+        let scraper = MetaScraper::new(
+            r#"
+            <html lang="en">
+            ...
+            </html>
+        "#,
+        );
+
+        let lang = scraper.lang();
+
+        assert_eq!(lang, Some("en".to_owned()));
     }
 }


### PR DESCRIPTION
## Overview

- Add `lang()` method that extracts the language attribute from HTML content.

## Related Issues

N/A

## Changes

- Add `lang()` method that extracts the language attribute from HTML content.

## Checklist

- [ ] The target branch for this PR is either `develop` or `release/*`.
- [ ] Unit tests have been added.
- [ ] All unit tests pass.
- [ ] Documentation has been updated if necessary.

## Additional Notes

N/A
